### PR TITLE
Replaced ember-cli silent-error with npm package

### DIFF
--- a/lib/ssh-adapter.js
+++ b/lib/ssh-adapter.js
@@ -3,7 +3,7 @@
 var CoreObject = require('core-object');
 var path = require('path');
 var Promise = require('ember-cli/lib/ext/promise');
-var SilentError = require('ember-cli/lib/errors/silent');
+var SilentError = require('silent-error');
 var ssh2 = require('ssh2');
 
 var noop = function () {};

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "ember-export-application-global": "^1.0.2",
     "express": "^4.8.5",
     "glob": "^4.0.5",
+    "silent-error": "^1.0.0",
     "sync-exec": "^0.5.0"
   },
   "keywords": [


### PR DESCRIPTION
EmberCLI's silent-error lib is deprecated and will be removed.
ember-cli-deploy removed its support of it last year:
https://github.com/ember-cli-deploy/ember-cli-deploy/pull/176

This uses the npm package instead
